### PR TITLE
perf: try to reduce ping overhead

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,10 +34,15 @@ struct ServeArgs {
 }
 
 #[get("/ping")]
-async fn ping() -> impl Responder {
+async fn ping_get() -> impl Responder {
     HttpResponse::Ok()
         .content_type(ContentType::json())
         .body("{\"message\": \"pong\"}")
+}
+
+#[head("/ping")]
+async fn ping_head() -> impl Responder {
+    HttpResponse::NoContent().finish()
 }
 
 #[derive(Deserialize)]
@@ -125,7 +130,8 @@ async fn main() -> std::io::Result<()> {
                     .service(download)
                     .service(upload)
                     .service(upload_options)
-                    .service(ping)
+                    .service(ping_get)
+                    .service(ping_head)
                     .service(static_resource)
                     .service(index)
             });

--- a/web/src/cases/ping.ts
+++ b/web/src/cases/ping.ts
@@ -2,8 +2,13 @@ import { BASE_URL } from '../const'
 
 export const ping = async () => {
   const now = performance.now()
-  const resp = await fetch(`${BASE_URL}/ping`, { method: 'GET' })
-  await resp.text()
+  const resp = await fetch(`${BASE_URL}/ping`, { method: 'HEAD' })
+
+  // we calculate time before consuming the response
   const time = performance.now() - now
+
+  // some bad browsers that will memory leak if we don't consume the response
+  await resp.arrayBuffer()
+
   return time
 }


### PR DESCRIPTION
The PR changes two things:

- `/ping` now also supports `HEAD` request, and it will respond with HTTP 204 with an empty response body
- The front-end now uses `HEAD` requests. And instead of using `json()` (which has JSON parse overhead) new implementation uses `arrayBuffer()`
  - Technically, we don't have to consume the body, but on some browsers (namely Safari), this would cause memory leaks (just like on Node.js). But since we return an empty response from the server, this should not cause any performance overhead anyway.
  - Also, with the PR, it now calculates the RTT before consuming the body.