### PR TITLE
ci: add Linux musl build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,17 +71,24 @@ jobs:
             file: linux-arm64
             tool: gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
           - runner: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            file: linux-arm64-musl
-            tool: musl-tools clang llvm gcc-multilib
-          - runner: ubuntu-latest
             target: i686-unknown-linux-gnu
             file: linux-386
             tool: gcc-multilib
+          # musl targets are useful for OpenWrt/Alpine-style environments.
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            file: linux-amd64-musl
+            tool: musl-tools
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            file: linux-arm64-musl
+            tool: musl-tools clang llvm gcc-multilib
     env:
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      CC_x86_64_unknown_linux_musl: musl-gcc
       CC_aarch64_unknown_linux_musl: clang
       AR_aarch64_unknown_linux_musl: llvm-ar
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-Clink-self-contained=yes -Clinker=rust-lld"
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-Clink-self-contained=yes -Clinker=rust-lld"
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ build-windows:
 	make build-arch TARGET=i686-pc-windows-msvc FILE=windows-386.exe
 
 build-linux:
+	# glibc targets
 	make build-arch TARGET=x86_64-unknown-linux-gnu FILE=linux-amd64
 	make build-arch TARGET=aarch64-unknown-linux-gnu FILE=linux-arm64
-	make build-arch TARGET=aarch64-unknown-linux-musl FILE=linux-arm64-musl
 	make build-arch TARGET=i686-unknown-linux-gnu FILE=linux-386
+	# musl targets for OpenWrt/Alpine-style environments
+	make build-arch TARGET=x86_64-unknown-linux-musl FILE=linux-amd64-musl
+	make build-arch TARGET=aarch64-unknown-linux-musl FILE=linux-arm64-musl


### PR DESCRIPTION
## Summary
- add an x86_64 Linux musl release target alongside the existing glibc targets
- keep aarch64 Linux musl in the release matrix and Makefile build path
- configure musl linker/rustflags for CI builds

## Verification
- git diff --check