### PR TITLE
feat: add web i18n support

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, useState, useRef } from 'react'
 import { HostChannel } from './channel'
 import styled from '@emotion/styled'
 import { Global, css } from '@emotion/react'
-import { ChannelsContext, ConfigContext } from './context'
+import { ChannelsContext, ConfigContext, I18nContext } from './context'
 import { CaseRunner } from './components/case-runner'
 import { CaseConfig } from './components/case-config'
 import { DEFAULT_CONFIG, CONFIG_STORAGE_KEY } from './const'
@@ -13,6 +13,7 @@ import { LightTheme, DarkTheme } from './styles/theme'
 import { $globalStyle } from './styles/global'
 import { Theme, Config } from './types'
 import { Footer } from './components/footer'
+import { createTranslator } from './i18n'
 
 const $Container = styled.div`
   padding: 12px 24px;
@@ -62,6 +63,7 @@ export function App() {
     return channelsRef.current
   }, [threadCount])
   const $theme = useMemo(() => css(config.theme === Theme.Dark ? DarkTheme : LightTheme), [config.theme])
+  const t = useMemo(() => createTranslator(config.locale), [config.locale])
 
   function handleConfigChange(newConfig: Config) {
     localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(newConfig))
@@ -71,32 +73,34 @@ export function App() {
   return (
     <ChannelsContext.Provider value={createChannels}>
       <ConfigContext.Provider value={config}>
-        <Global
-          styles={[
-            $globalStyle,
-            css`
-              body {
-                ${$theme}
-              }
-            `,
-          ]}
-        />
-        <$Container className={config.theme === Theme.Dark ? 'bp5-dark' : ''}>
-          <CaseConfig defaultValue={config} onChange={handleConfigChange} />
-          {config.duration !== Infinity ? (
-            <RunCaseOnce />
-          ) : (
-            <div
-              css={css`
-                display: flex;
-              `}
-            >
-              <CaseRunner title='Download' name='download' />
-              <CaseRunner title='Upload' name='upload' />
-            </div>
-          )}
-          <Footer />
-        </$Container>
+        <I18nContext.Provider value={t}>
+          <Global
+            styles={[
+              $globalStyle,
+              css`
+                body {
+                  ${$theme}
+                }
+              `,
+            ]}
+          />
+          <$Container className={config.theme === Theme.Dark ? 'bp5-dark' : ''}>
+            <CaseConfig defaultValue={config} onChange={handleConfigChange} />
+            {config.duration !== Infinity ? (
+              <RunCaseOnce />
+            ) : (
+              <div
+                css={css`
+                  display: flex;
+                `}
+              >
+                <CaseRunner title={t('app.download')} name='download' />
+                <CaseRunner title={t('app.upload')} name='upload' />
+              </div>
+            )}
+            <Footer />
+          </$Container>
+        </I18nContext.Provider>
       </ConfigContext.Provider>
     </ChannelsContext.Provider>
   )

--- a/web/src/components/case-config.tsx
+++ b/web/src/components/case-config.tsx
@@ -1,10 +1,21 @@
-import { useState, useRef, useMemo } from 'react'
-import { NumericInput, FormGroup, RadioGroup, Radio, Slider, Button, ButtonGroup, Collapse } from '@blueprintjs/core'
-import { RunningMode, SpeedMode, Config, RateUnit, Theme } from '../types'
+import { useState, useRef, useMemo, useContext } from 'react'
+import {
+  NumericInput,
+  FormGroup,
+  RadioGroup,
+  Radio,
+  Slider,
+  Button,
+  ButtonGroup,
+  Collapse,
+  HTMLSelect,
+} from '@blueprintjs/core'
+import { RunningMode, SpeedMode, Config, RateUnit, Theme, Locale } from '../types'
 import { css } from '@emotion/react'
 import { Var, ThemeVar } from '../styles/variable'
 import styled from '@emotion/styled'
 import { $valm } from '../styles/utils'
+import { I18nContext } from '../context'
 
 const $Header = styled.div`
   display: flex;
@@ -19,6 +30,9 @@ const $HeaderLeft = styled.div`
 
 const $HeaderRight = styled.div`
   flex: none;
+  display: flex;
+  gap: 8px;
+  align-items: center;
 `
 
 const $mgr8 = css`
@@ -224,6 +238,7 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
         defaultValue?.duration === Infinity ? 10 : (defaultValue?.duration ?? 10 * 1000) / 1000,
       ),
       theme: createFormField(defaultValue?.theme ?? Theme.Light, {}),
+      locale: createFormField(defaultValue?.locale ?? Locale.En, {}),
     })
 
     group.whenChanged((nv, ov) => {
@@ -249,14 +264,16 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
           unit: nv.unit,
           duration: nv.runningMode === RunningMode.ONCE ? nv.duration * 1000 : Infinity,
           theme: nv.theme,
+          locale: nv.locale,
         })
       }
     })
     return group
   }, [defaultValue])
   const [isAdvancedConfig, setAdvancedConfig] = useState(false)
+  const t = useContext(I18nContext)
 
-  const { runningMode, threadCount, speedRange, packCount, duration, unit, parallel, theme } = form.fields
+  const { runningMode, threadCount, speedRange, packCount, duration, unit, parallel, theme, locale } = form.fields
   return (
     <div>
       <$Header>
@@ -271,14 +288,14 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
               onClick={() => runningMode.onChange(RunningMode.ONCE)}
               icon={runningMode.value === RunningMode.ONCE ? 'small-tick' : undefined}
             >
-              单次测速
+              {t('config.mode.once')}
             </Button>
             <Button
               intent={runningMode.value === RunningMode.CONTINUE ? 'success' : 'none'}
               onClick={() => runningMode.onChange(RunningMode.CONTINUE)}
               icon={runningMode.value === RunningMode.CONTINUE ? 'small-tick' : undefined}
             >
-              持续压测
+              {t('config.mode.continue')}
             </Button>
           </ButtonGroup>
           <ButtonGroup
@@ -309,11 +326,20 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
               intent={isAdvancedConfig ? 'success' : 'none'}
               icon='settings'
             >
-              {isAdvancedConfig ? '切换到普通配置' : '切换到高级配置'}
+              {isAdvancedConfig ? t('config.advanced.hide') : t('config.advanced.show')}
             </Button>
           </ButtonGroup>
         </$HeaderLeft>
         <$HeaderRight>
+          <HTMLSelect
+            title={t('config.language')}
+            value={locale.value}
+            onChange={(e) => locale.onChange(e.currentTarget.value as Locale)}
+            minimal
+          >
+            <option value={Locale.Zh}>中文</option>
+            <option value={Locale.En}>EN</option>
+          </HTMLSelect>
           <Button
             intent='warning'
             icon={theme.value === Theme.Light ? 'moon' : 'flash'}
@@ -332,36 +358,27 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
           `}
         >
           {runningMode.value === RunningMode.ONCE && (
-            <FormGroup label='测速持续时间' labelInfo='(s)' key='duration' inline>
+            <FormGroup label={t('config.duration')} labelInfo='(s)' key='duration' inline>
               <NumericInput value={duration.value} onValueChange={duration.onChange} />
             </FormGroup>
           )}
-          <FormGroup
-            label='测速速度范围'
-            key='speedRange'
-            inline
-            helperText='低速模式下不会压榨系统资源；高速模式下会尽力压榨系统资源'
-          >
+          <FormGroup label={t('config.speedRange')} key='speedRange' inline helperText={t('config.speedRange.help')}>
             <RadioGroup
               selectedValue={speedRange.value}
               onChange={(e) => speedRange.onChange(e.currentTarget.value as SpeedMode)}
               inline
             >
-              <Radio label='低速 (通常网络小于 2.5G)' value={SpeedMode.LOW} />
-              <Radio label='高速 (通常网络大于 2.5G)' value={SpeedMode.HIGH} />
+              <Radio label={t('config.speedRange.low')} value={SpeedMode.LOW} />
+              <Radio label={t('config.speedRange.high')} value={SpeedMode.HIGH} />
             </RadioGroup>
           </FormGroup>
 
           {speedRange.value === SpeedMode.HIGH && (
-            <FormGroup
-              label='Thread Count'
-              key='threadCount'
-              helperText='测速 Worker 数量，根据你的机器性能适当选择。一般来说 3 个足够满足万兆网络测速。低速模式下，默认为 1 个，高速模式下，默认为系统逻辑处理器数量 - 1'
-            >
+            <FormGroup label={t('config.threadCount')} key='threadCount' helperText={t('config.threadCount.help')}>
               <Slider min={1} max={8} value={threadCount.value} onChange={threadCount.onChange} />
             </FormGroup>
           )}
-          <FormGroup label='Pack Count' key='packCount' helperText='控制单次请求下载或上传的数据大小'>
+          <FormGroup label={t('config.packCount')} key='packCount' helperText={t('config.packCount.help')}>
             <Slider
               min={8}
               max={256}
@@ -372,7 +389,7 @@ export function CaseConfig(props: { defaultValue?: Config; onChange?: (v: Config
               onChange={(v) => packCount.onChange(v)}
             />
           </FormGroup>
-          <FormGroup label='Parallal' helperText='并行数量，推荐 3 个，如果想要测试单线程，可以调整为 1'>
+          <FormGroup label={t('config.parallel')} helperText={t('config.parallel.help')}>
             <Slider
               min={1}
               max={16}

--- a/web/src/components/case-runner.tsx
+++ b/web/src/components/case-runner.tsx
@@ -1,12 +1,13 @@
 import React, { useContext, useRef, useState } from 'react'
 import { Button } from '@blueprintjs/core'
-import { ChannelsContext, ConfigContext } from '../context'
+import { ChannelsContext, ConfigContext, I18nContext } from '../context'
 import { css } from '@emotion/react'
 import { SpeedIndicator } from './speed-indicator'
 import { Subscription, zip } from 'rxjs'
 
 export function CaseRunner(props: { name: 'upload' | 'download'; title: string }) {
   const createChannels = useContext(ChannelsContext)
+  const t = useContext(I18nContext)
   const { duration, packCount, parallel } = useContext(ConfigContext)
   const [rate, setRate] = useState(-1)
   const [running, setRunning] = useState(false)
@@ -57,7 +58,7 @@ export function CaseRunner(props: { name: 'upload' | 'download'; title: string }
     >
       <h3>{props.title}</h3>
       <SpeedIndicator speed={rate === -1 ? undefined : rate} running={running} />
-      <Button onClick={onClick}>{!running ? 'Start' : 'Stop'}</Button>
+      <Button onClick={onClick}>{!running ? t('action.start') : t('action.stop')}</Button>
     </div>
   )
 }

--- a/web/src/components/footer.tsx
+++ b/web/src/components/footer.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { $talc } from '../styles/utils'
 import styled from '@emotion/styled'
 import { Var, ThemeVar } from '../styles/variable'
+import { I18nContext } from '../context'
 
 const FooterContainer = styled.div`
   ${$talc}
@@ -10,9 +11,6 @@ const FooterContainer = styled.div`
 `
 
 export function Footer() {
-  return (
-    <FooterContainer>
-      测试结果通常只能代表当前设备性能下所能跑到的实际数据， 没有任何理论参考价值，不能作为链路理论数据使用。
-    </FooterContainer>
-  )
+  const t = useContext(I18nContext)
+  return <FooterContainer>{t('footer.notice')}</FooterContainer>
 }

--- a/web/src/components/run-case-once.tsx
+++ b/web/src/components/run-case-once.tsx
@@ -2,7 +2,7 @@ import { SpeedIndicator } from './speed-indicator'
 import styled from '@emotion/styled'
 import { useState, useContext } from 'react'
 import { useRates } from '../hooks'
-import { ChannelsContext, ConfigContext } from '../context'
+import { ChannelsContext, ConfigContext, I18nContext } from '../context'
 import { zip, interval } from 'rxjs'
 import { rateFormatters } from '../utils'
 import { Button, Intent } from '@blueprintjs/core'
@@ -37,20 +37,13 @@ enum RunningStep {
   DONE,
 }
 
-const RunningStepLabels: Record<RunningStep, string> = {
-  [RunningStep.NONE]: 'Start',
-  [RunningStep.DOWNLOAD]: 'Downloading',
-  [RunningStep.PING]: 'Pinging',
-  [RunningStep.UPLOAD]: 'Uploading',
-  [RunningStep.DONE]: 'Restart',
-}
-
 export function RunCaseOnce() {
   const [dlRate, setDlRate] = useState(-1)
   const [ulRate, setUlRate] = useState(-1)
   const [ttl, pushTTL, clearTTL] = useRates(5)
   const [step, setStep] = useState(RunningStep.NONE)
   const createChannels = useContext(ChannelsContext)
+  const t = useContext(I18nContext)
   const { duration, parallel, packCount, unit } = useContext(ConfigContext)
 
   const _start = async () => {
@@ -101,7 +94,7 @@ export function RunCaseOnce() {
   const start = () => {
     _start().catch(() => {
       showToast({
-        message: `Error, Please check environment`,
+        message: t('error.environment'),
         intent: Intent.DANGER,
         icon: 'warning-sign',
       })
@@ -113,17 +106,17 @@ export function RunCaseOnce() {
     <div>
       <$Header>
         <$HeaderCase>
-          <$CaseTitle>Ping</$CaseTitle>
+          <$CaseTitle>{t('app.ping')}</$CaseTitle>
           <$CaseContent>{step >= RunningStep.PING ? `${ttl.toFixed(2)} ms` : '--'}</$CaseContent>
         </$HeaderCase>
 
         <$HeaderCase>
-          <$CaseTitle>Download</$CaseTitle>
+          <$CaseTitle>{t('app.download')}</$CaseTitle>
           <$CaseContent>{step >= RunningStep.DOWNLOAD ? rateFormatters[unit](dlRate) : '--'}</$CaseContent>
         </$HeaderCase>
 
         <$HeaderCase>
-          <$CaseTitle>Upload</$CaseTitle>
+          <$CaseTitle>{t('app.upload')}</$CaseTitle>
           <$CaseContent>{step >= RunningStep.UPLOAD ? rateFormatters[unit](ulRate) : '--'}</$CaseContent>
         </$HeaderCase>
       </$Header>
@@ -137,7 +130,15 @@ export function RunCaseOnce() {
         `}
       >
         <Button onClick={start} disabled={step !== RunningStep.NONE && step !== RunningStep.DONE}>
-          {RunningStepLabels[step]}
+          {
+            {
+              [RunningStep.NONE]: t('action.start'),
+              [RunningStep.DOWNLOAD]: t('state.downloading'),
+              [RunningStep.PING]: t('state.pinging'),
+              [RunningStep.UPLOAD]: t('state.uploading'),
+              [RunningStep.DONE]: t('action.restart'),
+            }[step]
+          }
         </Button>
       </div>
     </div>

--- a/web/src/components/speed-indicator.tsx
+++ b/web/src/components/speed-indicator.tsx
@@ -1,7 +1,7 @@
 import { ProgressBar, ProgressBarProps, Tag } from '@blueprintjs/core'
 import { css } from '@emotion/react'
 import { memo, useContext } from 'react'
-import { ConfigContext } from '../context'
+import { ConfigContext, I18nContext } from '../context'
 import { rateFormatters } from '../utils'
 
 const K = 1024
@@ -16,6 +16,7 @@ export const SpeedIndicator = memo(function SpeedIndicator({
   running?: boolean
 }) {
   const { unit } = useContext(ConfigContext)
+  const t = useContext(I18nContext)
   const formatter = rateFormatters[unit]
   const pbp: ProgressBarProps = {}
   if (typeof speed === 'number') {
@@ -55,7 +56,7 @@ export const SpeedIndicator = memo(function SpeedIndicator({
         `}
         intent={pbp.intent}
       >
-        {speed !== undefined ? formatter(speed) : 'Waiting...'}
+        {speed !== undefined ? formatter(speed) : t('state.waiting')}
       </Tag>
     </div>
   )

--- a/web/src/const.ts
+++ b/web/src/const.ts
@@ -1,7 +1,10 @@
 import { Config, SpeedMode, RateUnit, Theme } from './types'
+import { normalizeLocale } from './i18n'
 
 export const BASE_URL = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3300'
 export const CONFIG_STORAGE_KEY = 'homebox:config'
+
+const systemLocale = typeof navigator !== 'undefined' ? normalizeLocale(navigator.language) : normalizeLocale()
 
 const systemTheme = (() => {
   const matchMedia = (globalThis as { matchMedia?: (query: string) => { matches: boolean } }).matchMedia
@@ -24,4 +27,5 @@ export const DEFAULT_CONFIG: Config = {
   parallel: 3,
   unit: RateUnit.BIT,
   theme: systemTheme,
+  locale: systemLocale,
 }

--- a/web/src/context.ts
+++ b/web/src/context.ts
@@ -2,8 +2,10 @@ import { createContext } from 'react'
 import { HostChannel } from './channel'
 import type { ChannelModule } from './worker'
 import { Config } from './types'
+import { createTranslator } from './i18n'
 import { DEFAULT_CONFIG } from './const'
 
 export const ChannelsContext = createContext<() => Promise<HostChannel<ChannelModule>[]>>(null as any)
 
 export const ConfigContext = createContext<Config>(DEFAULT_CONFIG)
+export const I18nContext = createContext(createTranslator(DEFAULT_CONFIG.locale))

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -1,0 +1,83 @@
+import { Locale } from './types'
+
+export const messages = {
+  en: {
+    'app.download': 'Download',
+    'app.upload': 'Upload',
+    'app.ping': 'Ping',
+    'action.start': 'Start',
+    'action.stop': 'Stop',
+    'action.restart': 'Restart',
+    'state.waiting': 'Waiting...',
+    'state.downloading': 'Downloading',
+    'state.uploading': 'Uploading',
+    'state.pinging': 'Pinging',
+    'error.environment': 'Error, please check environment',
+    'config.mode.once': 'Single test',
+    'config.mode.continue': 'Continuous test',
+    'config.advanced.show': 'Switch to advanced config',
+    'config.advanced.hide': 'Switch to simple config',
+    'config.duration': 'Test duration',
+    'config.speedRange': 'Test speed range',
+    'config.speedRange.help':
+      'Low speed mode avoids exhausting system resources; high speed mode uses as many system resources as possible.',
+    'config.speedRange.low': 'Low speed (usually below 2.5G)',
+    'config.speedRange.high': 'High speed (usually above 2.5G)',
+    'config.threadCount': 'Thread Count',
+    'config.threadCount.help':
+      'Number of test workers. Tune this based on device performance. Usually 3 workers are enough for 10G network tests. Low speed mode defaults to 1; high speed mode defaults to logical processors - 1.',
+    'config.packCount': 'Pack Count',
+    'config.packCount.help': 'Controls the amount of data downloaded or uploaded per request.',
+    'config.parallel': 'Parallel',
+    'config.parallel.help': 'Parallel request count. 3 is recommended; set it to 1 for single-thread tests.',
+    'config.language': 'Language',
+    'footer.notice':
+      'Test results usually only represent the real data that can be achieved under the current device performance. They have no theoretical reference value and should not be used as theoretical link data.',
+  },
+  zh: {
+    'app.download': '下载',
+    'app.upload': '上传',
+    'app.ping': 'Ping',
+    'action.start': '开始',
+    'action.stop': '停止',
+    'action.restart': '重新开始',
+    'state.waiting': '等待中...',
+    'state.downloading': '下载中',
+    'state.uploading': '上传中',
+    'state.pinging': 'Ping 中',
+    'error.environment': '出错了，请检查运行环境',
+    'config.mode.once': '单次测速',
+    'config.mode.continue': '持续压测',
+    'config.advanced.show': '切换到高级配置',
+    'config.advanced.hide': '切换到普通配置',
+    'config.duration': '测速持续时间',
+    'config.speedRange': '测速速度范围',
+    'config.speedRange.help': '低速模式下不会压榨系统资源；高速模式下会尽力压榨系统资源',
+    'config.speedRange.low': '低速 (通常网络小于 2.5G)',
+    'config.speedRange.high': '高速 (通常网络大于 2.5G)',
+    'config.threadCount': 'Thread Count',
+    'config.threadCount.help':
+      '测速 Worker 数量，根据你的机器性能适当选择。一般来说 3 个足够满足万兆网络测速。低速模式下，默认为 1 个，高速模式下，默认为系统逻辑处理器数量 - 1',
+    'config.packCount': 'Pack Count',
+    'config.packCount.help': '控制单次请求下载或上传的数据大小',
+    'config.parallel': 'Parallel',
+    'config.parallel.help': '并行数量，推荐 3 个，如果想要测试单线程，可以调整为 1',
+    'config.language': '语言',
+    'footer.notice':
+      '测试结果通常只能代表当前设备性能下所能跑到的实际数据， 没有任何理论参考价值，不能作为链路理论数据使用。',
+  },
+} as const
+
+export type TranslationKey = keyof typeof messages.en
+
+export function normalizeLocale(locale?: string): Locale {
+  if (locale?.toLowerCase().startsWith('zh')) {
+    return Locale.Zh
+  }
+  return Locale.En
+}
+
+export function createTranslator(locale: Locale) {
+  const localeMessages = messages[locale] ?? messages.en
+  return (key: TranslationKey) => localeMessages[key] ?? messages.en[key]
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,6 +29,11 @@ export enum RateUnit {
   BYTE = 'byte',
 }
 
+export enum Locale {
+  En = 'en',
+  Zh = 'zh',
+}
+
 export interface Config {
   speedMode: SpeedMode
   threadCount: number
@@ -37,6 +42,7 @@ export interface Config {
   duration: number
   parallel: number
   theme: Theme
+  locale: Locale
 }
 
 export enum Theme {


### PR DESCRIPTION
## Summary
- add a lightweight web i18n message catalog with Chinese and English translations
- persist locale in the existing config and default from the browser language
- wire translated labels into the main speed test UI and add a language toggle

## Verification
- pnpm build

## Note
- pnpm lint is currently blocked by the existing ESLint 7.1 config not recognizing the es2021 environment.